### PR TITLE
fix: Enable fork processing to make renovate work in forked repositories

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":automergeMinor"]
+  "extends": ["config:base", ":automergeMinor"],
+  "forkProcessing": "enabled"
 }


### PR DESCRIPTION
## Summary

- Add "forkProcessing": "enabled" to renovate.json to make Renovate work in forked repositories

## Background

PR #3 added a Renovate configuration to this repository. However, Renovate does not process forked repositories by default.

## Changes

 Added "forkProcessing": "enabled" option to renovate.json

## Reference

- https://docs.renovatebot.com/configuration-options/#forkprocessing
- Related PR: #3